### PR TITLE
Add loader for Berean Standard Bible

### DIFF
--- a/db_loaders/__init__.py
+++ b/db_loaders/__init__.py
@@ -1,0 +1,1 @@
+"""Database loader utilities."""

--- a/db_loaders/load_bsb.py
+++ b/db_loaders/load_bsb.py
@@ -1,0 +1,120 @@
+"""Utilities to load the Berean Standard Bible into ChromaDB."""
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Dict, Iterable, List
+
+import requests
+import chromadb
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+from openai import OpenAI
+
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+VERSE_RE = re.compile(r"^(?P<book>[0-9A-Za-z ]+) (?P<chapter>\d+):(?P<verse>\d+) (?P<text>.+)$")
+
+
+def fetch_verses() -> List[Dict[str, str]]:
+    """Fetch the BSB text and parse into verse records."""
+    url = "https://bereanbible.com/bsb.txt"
+    logger.info("Fetching %s", url)
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+
+    verses: List[Dict[str, str]] = []
+    for line in resp.text.splitlines():
+        match = VERSE_RE.match(line)
+        if not match:
+            continue
+        book = match.group("book")
+        chapter = match.group("chapter")
+        verse = match.group("verse")
+        text = match.group("text").strip()
+        ref = f"{book} {chapter}:{verse}"
+        verses.append(
+            {
+                "id": str(uuid.uuid4()),
+                "book": book,
+                "chapter": chapter,
+                "verse": verse,
+                "ref": ref,
+                "text": text,
+            }
+        )
+    logger.info("Parsed %d verses", len(verses))
+    return verses
+
+
+def group_semantic_chunks(verses: Iterable[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Use GPT-5 to group contiguous verses into semantic chunks."""
+    client = OpenAI()
+    verse_lines = [f"{v['ref']} {v['text']}" for v in verses]
+    prompt = (
+        "Group the following Bible verses into semantic chunks. "
+        "Return a JSON array of objects with 'ref' and 'text'."
+    )
+    response = client.responses.create(
+        model="gpt-5-mini",
+        reasoning={"effort": "low"},
+        input=[
+            {"role": "system", "content": "You group verses into coherent sections."},
+            {"role": "user", "content": "\n".join(verse_lines)},
+            {"role": "user", "content": prompt},
+        ],
+        response_format={"type": "json_object"},
+    )
+    content = response.output[0].content[0].text  # type: ignore[attr-defined]
+    data = json.loads(content)
+    chunks = data.get("chunks", [])
+    results: List[Dict[str, str]] = []
+    for chunk in chunks:
+        ref = chunk.get("ref")
+        text = chunk.get("text")
+        if not (ref and text):
+            continue
+        results.append({"id": str(uuid.uuid4()), "ref": ref, "text": text})
+    logger.info("Generated %d semantic chunks", len(results))
+    return results
+
+
+def load():
+    """Load verses and semantic chunks into ChromaDB."""
+    verses = fetch_verses()
+    semantic_chunks = group_semantic_chunks(verses)
+
+    client = chromadb.PersistentClient(path="./data")
+    try:
+        client.delete_collection("bibles")
+    except Exception:
+        logger.warning("No existing collection to delete")
+
+    collection = client.create_collection(
+        name="bibles",
+        embedding_function=OpenAIEmbeddingFunction(),
+    )
+
+    collection.add(
+        ids=[v["id"] for v in verses],
+        documents=[v["text"] for v in verses],
+        metadatas=[{"ref": v["ref"], "book": v["book"], "chapter": v["chapter"], "verse": v["verse"], "type": "verse"} for v in verses],
+    )
+
+    collection.add(
+        ids=[c["id"] for c in semantic_chunks],
+        documents=[c["text"] for c in semantic_chunks],
+        metadatas=[{"ref": c["ref"], "type": "semantic"} for c in semantic_chunks],
+    )
+
+    logger.info("Inserted %d verses and %d semantic chunks", len(verses), len(semantic_chunks))
+
+
+def main():
+    load()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_load_bsb.py
+++ b/tests/test_load_bsb.py
@@ -1,0 +1,111 @@
+import json
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+import os
+import chromadb
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("GROQ_API_KEY", "test")
+os.environ.setdefault("META_VERIFY_TOKEN", "test")
+os.environ.setdefault("META_WHATSAPP_TOKEN", "test")
+os.environ.setdefault("META_PHONE_NUMBER_ID", "test")
+os.environ.setdefault("META_APP_SECRET", "test")
+os.environ.setdefault("FACEBOOK_USER_AGENT", "test")
+os.environ.setdefault("BASE_URL", "http://example.com")
+from db_loaders import load_bsb
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def test_genesis_processing(monkeypatch, tmp_path):
+    sample_text = (
+        "Genesis 1:1 In the beginning God created the heavens and the earth.\n"
+        "Genesis 1:2 Now the earth was formless and void, and darkness was over the surface of the deep.\n"
+        "Exodus 1:1 These are the names of the sons of Israel who went to Egypt with Jacob, each with his family.\n"
+    )
+
+    def fake_get(url, timeout):
+        return DummyResponse(sample_text)
+
+    monkeypatch.setattr(load_bsb.requests, "get", fake_get)
+
+    class FakeClient:
+        def __init__(self):
+            self.responses = SimpleNamespace(
+                create=lambda **kwargs: SimpleNamespace(
+                    output=[
+                        SimpleNamespace(
+                            content=[
+                                SimpleNamespace(
+                                    text=json.dumps(
+                                        {
+                                            "chunks": [
+                                                {
+                                                    "ref": "Genesis 1:1-2",
+                                                    "text": "In the beginning...",
+                                                }
+                                            ]
+                                        }
+                                    )
+                                )
+                            ]
+                        )
+                    ]
+                )
+            )
+
+    monkeypatch.setattr(load_bsb, "OpenAI", FakeClient)
+
+    verses = load_bsb.fetch_verses()
+    genesis_verses = []
+    for verse in verses:
+        if verse["book"] != "Genesis":
+            break
+        genesis_verses.append(verse)
+
+    assert len(genesis_verses) == 2
+    assert genesis_verses[0]["ref"] == "Genesis 1:1"
+    assert genesis_verses[-1]["ref"] == "Genesis 1:2"
+
+    semantic_chunks = load_bsb.group_semantic_chunks(genesis_verses)
+    assert semantic_chunks[0]["ref"] == "Genesis 1:1-2"
+
+    class DummyEmbeddingFunction:
+        def __call__(self, input):
+            return [[0.0, 0.0, 0.0] for _ in input]
+
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.create_collection(
+        "bibles", embedding_function=DummyEmbeddingFunction()
+    )
+    collection.add(
+        ids=[v["id"] for v in genesis_verses],
+        documents=[v["text"] for v in genesis_verses],
+        metadatas=[
+            {
+                "ref": v["ref"],
+                "book": v["book"],
+                "chapter": v["chapter"],
+                "verse": v["verse"],
+                "type": "verse",
+            }
+            for v in genesis_verses
+        ],
+    )
+    collection.add(
+        ids=[c["id"] for c in semantic_chunks],
+        documents=[c["text"] for c in semantic_chunks],
+        metadatas=[{"ref": c["ref"], "type": "semantic"} for c in semantic_chunks],
+    )
+
+    verses_in_db = collection.get(where={"type": "verse"})
+    assert len(verses_in_db["ids"]) == len(genesis_verses)
+    assert all(md["book"] == "Genesis" for md in verses_in_db["metadatas"])


### PR DESCRIPTION
## Summary
- add `db_loaders` package with loader for the Berean Standard Bible
- fetch BSB text, chunk verses, group them via GPT-5, and store in ChromaDB collection
- add test that processes Genesis and checks inserted verses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5d8ef75c832fa830155ebde6fb4f