### PR TITLE
Remove __future__ import from Bible loader

### DIFF
--- a/db_loaders/load_bsb.py
+++ b/db_loaders/load_bsb.py
@@ -1,5 +1,4 @@
 """Utilities to load the Berean Standard Bible into ChromaDB."""
-from __future__ import annotations
 
 import json
 import re


### PR DESCRIPTION
## Summary
- drop `from __future__ import annotations` in `load_bsb.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b4a9c1afc832f9ae14591e6e296cb